### PR TITLE
Have `make selfsigned` now call `lc-tlscert`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ gem:
 test: all vendor/bundle/.GemfileModT
 	bundle exec rspec $(TESTS)
 
+selfsigned: | bin/lc-tlscert
+	bin/lc-tlscert
+
+
 doc:
 	@npm --version >/dev/null || (echo "'npm' not found. You need to install node.js.")
 	@npm install doctoc >/dev/null || (echo "Failed to perform local install of doctoc.")


### PR DESCRIPTION
`make selfsigned` was pretty nifty. Even though the process is
different, maybe we should keep the target in the Makefile? I have `make
selfsigned` depend and run `lcs-tlscert`.
