### PR TITLE
Need to copy lib/logstash and lib/log-courier to logstash

### DIFF
--- a/docs/LogstashIntegration.md
+++ b/docs/LogstashIntegration.md
@@ -40,7 +40,7 @@ the installation, which will require an internet connection.
 Now install the Logstash plugins.
 
 		cd <log-courier-source>
-		cp -rvf lib/logstash /opt/logstash/lib
+		cp -rvf lib /opt/logstash
 
 ## Remote Installation
 


### PR DESCRIPTION
To make the plugin really work properly you need to copy both lib/logstash and lib/log-courier to /opt/logstash/lib.  This is especially important if you want to create a separate --pluginpath directory for log-courier so you can keep the logstash and log-courier code separate, making it easier to handle with Ansible, Puppet, Chef, etc.

I used:

LSDIR=location of logstash install
cd $LSDIR
export GEM_HOME=$LSDIR../log-courier
java -jar vendor/jar/jruby-complete-1.7.11.jar -S gem install <path-to-gem>

cd <log-courier-source>
cp -rvf lib $LSDIR../log-courier

Then call logstash this way:

$LSDIR/bin/logstash agent \
        -f <path to conf file> \
        --pluginpath $LSDIR/../log-courier/lib \

to include that pluginpath
