### PR TITLE
Expanding environment variables in the config file. 

### DIFF
--- a/src/lc-lib/core/config.go
+++ b/src/lc-lib/core/config.go
@@ -203,6 +203,12 @@ func (c *Config) loadFile(path string) (stripped *bytes.Buffer, err error) {
   return
 }
 
+func ExpandEnv(config_in []byte) (config_out []byte) {	
+	config_str := string(config_in)	
+	config_out = []byte(os.ExpandEnv(config_str))
+	return
+}
+
 // TODO: Config from a TOML? Maybe a custom one
 func (c *Config) Load(path string) (err error) {
   var data *bytes.Buffer
@@ -214,7 +220,7 @@ func (c *Config) Load(path string) (err error) {
 
   // Pull the entire structure into raw_config
   raw_config := make(map[string]interface{})
-  if err = json.Unmarshal(data.Bytes(), &raw_config); err != nil {
+  if err = json.Unmarshal(ExpandEnv(data.Bytes()), &raw_config); err != nil {
     return
   }
 
@@ -245,7 +251,7 @@ func (c *Config) Load(path string) (err error) {
 
       // Pull the structure into raw_include
       raw_include := make([]interface{}, 0)
-      if err = json.Unmarshal(data.Bytes(), &raw_include); err != nil {
+      if err = json.Unmarshal(ExpandEnv(data.Bytes()), &raw_include); err != nil {
         return
       }
 


### PR DESCRIPTION
The idea is to have common configuration file, which can be deployed on windows or linux. I.e.
{
  "network": {
    "servers": [ "host:port" ],
    "ssl ca": "${MY_HOME}/log-courier.crt",
    "ssl certificate": "${MY_HOME}/log-courier.crt",
    "ssl key": "${MY_HOME}/log-courier.key"
  },
  "files": [
    {
      "paths": [ 
        "${MY_LOG_DIR}/app1/_.log",
        "${MY_LOG_DIR}/app2/_.log"],
      "fields": { "type": "sometype" }
    }
  ]
}

Potentially, properties could be environment variables, os.ExpandEnv method solves the issue smoothly.

From go lang documentation:
ExpandEnv replaces ${var} or $var in the string according to the values of the current environment variables. References to undefined variables are replaced by the empty string. 
