### PR TITLE
Remove use_bigdecimal JrJackson option as Logstash does not support BigD...

### DIFF
--- a/lib/log-courier/server.rb
+++ b/lib/log-courier/server.rb
@@ -59,7 +59,7 @@ module LogCourier
 
       # Load the json adapter
       @json_adapter = MultiJson.adapter.instance
-      @json_options = { raw: true, use_bigdecimal: true }
+      @json_options = { raw: true }
     end
 
     def run(&block)


### PR DESCRIPTION
...ecimal

A severe side effect is also that the use_bigdecimal option leaks and persists in the JrJackson library, meaning all json filter and codec operations will begin to create BigDecimal objects even without the option.
Fixes #103