### PR TITLE
Update server_zmq.rb

### DIFF
--- a/lib/log-courier/server_zmq.rb
+++ b/lib/log-courier/server_zmq.rb
@@ -85,7 +85,7 @@ module LogCourier
 
         bind = 'tcp://' + @options[:address] + (@options[:port] == 0 ? ':*' : ':' + @options[:port].to_s)
         rc = @socket.bind(bind)
-        fail 'failed to bind at ' + bind + ': ' + rZMQ::Util.error_string unless ZMQ::Util.resultcode_ok?(rc)
+        fail 'failed to bind at ' + bind + ': ' + ZMQ::Util.error_string unless ZMQ::Util.resultcode_ok?(rc)
 
         # Lookup port number that was allocated in case it was set to 0
         endpoint = ''


### PR DESCRIPTION
I feel almost stupid to send in a pull request for this: There is a typo in line 88: "rZMQ::Util.error_string" instead of "ZMQ::Util.error_string".