### PR TITLE
Update gems to work with Logstash 1.5 beta2

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To install the Log Courier repository, download the corresponding `.repo`
 configuration file below, and place it in `/etc/yum.repos.d`. Log Courier may
 then be installed using `yum install log-courier`.
 
-* **CentOS/RedHat 6.x**: [driskell-log-courier-epel-6.repo](https://copr.fedoraproject.org/coprs/driskell/log-courier/repo/epel-6/driskell-log-courier-epel-6.repo) 
+* **CentOS/RedHat 6.x**: [driskell-log-courier-epel-6.repo](https://copr.fedoraproject.org/coprs/driskell/log-courier/repo/epel-6/driskell-log-courier-epel-6.repo)
 * **CentOS/RedHat 7.x**:
 [driskell-log-courier-epel-7.repo](https://copr.fedoraproject.org/coprs/driskell/log-courier/repo/epel-6/driskell-log-courier-epel-7.repo)
 
@@ -112,7 +112,8 @@ Log Courier does not utilise the lumberjack Logstash plugin and instead uses its
 own custom plugin. This allows significant enhancements to the integration far
 beyond the lumberjack protocol allows.
 
-Install using the Logstash 1.5+ Plugin manager.
+You may install the input plugin using the Logstash 1.5 Plugin manager. (Tested
+with beta1 and beta2.)
 
 	cd /path/to/logstash
 	bin/logstash plugin install logstash-input-log-courier

--- a/docs/LogstashIntegration.md
+++ b/docs/LogstashIntegration.md
@@ -17,14 +17,14 @@ Log Courier is built to work seamlessly with [Logstash](http://logstash.net)
 
 ## Installation
 
-### Logstash 1.5+ Plugin Manager
+### Logstash 1.5 Plugin Manager
 
 Logstash 1.5 introduces a new plugin manager that makes installing additional
 plugins extremely easy.
 
 Simply run the following commands to install the latest stable version of the
 Log Courier plugins. If you are only receiving events, you only need to install
-the input plugin.
+the input plugin. (Tested with beta1 and beta2.)
 
 		cd /path/to/logstash
 		bin/logstash plugin install logstash-input-log-courier

--- a/logstash-input-log-courier.gemspec.tmpl
+++ b/logstash-input-log-courier.gemspec.tmpl
@@ -13,8 +13,8 @@ Gem::Specification.new do |gem|
     lib/logstash/inputs/courier.rb
   )
 
-  gem.metadata = { 'logstash_plugin' => 'true', 'group' => 'input' }
+  gem.metadata = { 'logstash_plugin' => 'true', 'logstash_group' => 'input' }
 
-  gem.add_runtime_dependency 'logstash', '~> 1.4'
+  gem.add_runtime_dependency 'logstash-core', '~> 1.4'
   gem.add_runtime_dependency 'log-courier', '= <VERSION>'
 end

--- a/logstash-output-log-courier.gemspec.tmpl
+++ b/logstash-output-log-courier.gemspec.tmpl
@@ -13,8 +13,8 @@ Gem::Specification.new do |gem|
     lib/logstash/outputs/courier.rb
   )
 
-  gem.metadata = { 'logstash_plugin' => 'true', 'group' => 'input' }
+  gem.metadata = { 'logstash_plugin' => 'true', 'logstash_group' => 'input' }
 
-  gem.add_runtime_dependency 'logstash', '~> 1.4'
+  gem.add_runtime_dependency 'logstash-core', '~> 1.4'
   gem.add_runtime_dependency 'log-courier', '= <VERSION>'
 end


### PR DESCRIPTION
Fixes #121 

- [x] Test for regression with Logstash 1.5 beta1

The plan is to merge this only once beta2 is released (or 1.5 is released.)