### PR TITLE
Fix init script #217

### DIFF
--- a/contrib/initscripts/debian-upstart.init
+++ b/contrib/initscripts/debian-upstart.init
@@ -107,6 +107,7 @@ case "$1" in
     else
       log_end_msg 0
     fi
+    ;;
   *)
     echo "Usage: $0 {start|stop|status|restart|force-reload|configtest}" >&2
     exit 3


### PR DESCRIPTION
Add missing ;; after configtest action to fix debian init script #217 