### PR TITLE
Allow Go version 1.5 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,8 @@ setup_root:
 	build/setup_root
 
 prepare: | fix_version setup_root
-	@go version >/dev/null || (echo "Go not found. You need to install Go version 1.2-1.4: http://golang.org/doc/install"; false)
-	@go version | grep -q 'go version go1.[234]' || (echo "Go version 1.2-1.4, you have a version of Go that is not supported."; false)
+	@go version >/dev/null || (echo "Go not found. You need to install Go version 1.2-1.5: http://golang.org/doc/install"; false)
+	@go version | grep -q 'go version go1.[2345]' || (echo "Go version 1.2-1.5, you have a version of Go that is not supported."; false)
 	@echo "GOPATH: $${GOPATH}"
 
 bin/%: prepare


### PR DESCRIPTION
When I downloaded the package, `make` complained about my version of go. I tweaked the Makefile with these changes and it compiled flawlessly.