### PR TITLE
Fix LOG_COURIER_ARGS handling in systemd unit file

### DIFF
--- a/contrib/initscripts/redhat-systemd.service
+++ b/contrib/initscripts/redhat-systemd.service
@@ -5,8 +5,8 @@ After=syslog.target network.target remote-fs.target nss-lookup.target
 [Service]
 Type=simple
 EnvironmentFile=/etc/sysconfig/log-courier
-ExecStartPre=/usr/sbin/log-courier ${LOG_COURIER_ARGS} -config-test
-ExecStart=/usr/sbin/log-courier ${LOG_COURIER_ARGS}
+ExecStartPre=/usr/sbin/log-courier $LOG_COURIER_ARGS -config-test
+ExecStart=/usr/sbin/log-courier $LOG_COURIER_ARGS
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true


### PR DESCRIPTION
Fixes driskell/log-courier/issues/248