### PR TITLE
Fix debian package build information

### DIFF
--- a/contrib/README-deb.md
+++ b/contrib/README-deb.md
@@ -11,7 +11,11 @@ archive, setup the source for debian building, and build the package.
     git clone https://github.com/driskell/log-courier
     tar -czf log-courier_VERSION.orig.tar.gz log-courier
     cd log-courier
-    mv contrib/deb debian
+    # You can build the package for either upstart or systemd
+    # upstart
+    mv contrib/deb-upstart debian
+    # systemd
+    # mv contrib/deb-systemd debian
     dpkg-buildpackage
 
 Packaging on Wheezy

--- a/contrib/deb-systemd/postinst
+++ b/contrib/deb-systemd/postinst
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 adduser --quiet --system --home /var/lib/log-courier --no-create-home --group log-courier
+mkdir -p /var/run/log-courier
 chown log-courier: /var/lib/log-courier /var/run/log-courier
 
 if [ -f /var/run/log-courier.pid ]; then

--- a/contrib/deb-upstart/postinst
+++ b/contrib/deb-upstart/postinst
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 adduser --quiet --system --home /var/lib/log-courier --no-create-home --group log-courier
+mkdir -p /var/run/log-courier
 chown log-courier: /var/lib/log-courier /var/run/log-courier
 
 if [ -f /var/run/log-courier.pid ]; then


### PR DESCRIPTION
Fix debian package build information:
1) create the /var/run/log-courier directory after the install
2) update documentation to reflect the deb-upstart and deb-systemd directories