### PR TITLE
Add DEBHELPER to postinst

### DIFF
--- a/contrib/deb-systemd/postinst
+++ b/contrib/deb-systemd/postinst
@@ -7,3 +7,7 @@ chown log-courier: /var/lib/log-courier /var/run/log-courier
 if [ -f /var/run/log-courier.pid ]; then
 	mv /var/run/log-courier.pid /var/run/log-courier/log-courier.pid
 fi
+
+#DEBHELPER#
+
+exit 0

--- a/contrib/deb-upstart/postinst
+++ b/contrib/deb-upstart/postinst
@@ -7,3 +7,7 @@ chown log-courier: /var/lib/log-courier /var/run/log-courier
 if [ -f /var/run/log-courier.pid ]; then
 	mv /var/run/log-courier.pid /var/run/log-courier/log-courier.pid
 fi
+
+#DEBHELPER#
+
+exit 0


### PR DESCRIPTION
Without this the systemd scripts are installed, but dh can't put its magic into the postinst to make sure the service starts at boot time. So after a reboot log-courier doesn't restart.

Haven't tested on upstart, but all postinst/prerm/etc scripts should have this anyway, so it's unlikely to cause any issues.
