### PR TITLE
`hold time` configuration to close deleted files after defined period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 2.6.0
+
+Future
+
+Log Courier
+
+- Implement `hold time` configuration option with a default of 96 hours. Log Courier will now, by default, only hold open deleted files for a maximum of 96 hours after deletion is detected, regardless of whether its contents finish processing. A warning is logged if data has been lost when the file closed. This ensures disks do not fill when the pipeline is blocked. 96 hours was chosen as the default to allow a minimum of a few days to detect and repair a pipeline issue, as some roll over configurations delete the file during the very first rollover to replace it with a compressed version.
+- The `dead time` configuration will no longer be checked if the pipeline is completely blocked. Previously, it would be processed during complete pipeline blockage only, meaning a deleted file could be closed and data lost if the pipeline was completely blocked for the specified `dead time` period. This was unintended behaviour and would not trigger if the pipeline was extremely slow as the `dead time` would reset upon each successful read. Documentation has also been updated to clarify that `dead time` is not based on the modification time of the file, but the time of the last successful read when the pipeline is moving, however slow that may be.
+
 ## 2.5.4
 
 8th February 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Log Courier
 
 - Implement `hold time` configuration option with a default of 96 hours. Log Courier will now, by default, only hold open deleted files for a maximum of 96 hours after deletion is detected, regardless of whether its contents finish processing. A warning is logged if data has been lost when the file closed. This ensures disks do not fill when the pipeline is blocked. 96 hours was chosen as the default to allow a minimum of a few days to detect and repair a pipeline issue, as some roll over configurations delete the file during the very first rollover to replace it with a compressed version.
 - The `dead time` configuration will no longer be checked if the pipeline is completely blocked. Previously, it would be processed during complete pipeline blockage only, meaning a deleted file could be closed and data lost if the pipeline was completely blocked for the specified `dead time` period. This was unintended behaviour and would not trigger if the pipeline was extremely slow as the `dead time` would reset upon each successful read. Documentation has also been updated to clarify that `dead time` is not based on the modification time of the file, but the time of the last successful read when the pipeline is moving, however slow that may be.
+- Fixed a crash when `add offset field` is set to false and `enable ecs` is set to true
 
 ## 2.5.4
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -21,6 +21,7 @@
     - [`add timezone field`](#add-timezone-field)
     - [`codecs`](#codecs)
     - [`dead time`](#dead-time)
+    - [`hold_time`](#hold_time)
     - [`fields`](#fields)
   - [`admin`](#admin)
     - [`enabled`](#enabled)
@@ -313,13 +314,25 @@ Aside from "plain", the following codecs are available at this time.
 Duration. Optional. Default: "1h"  
 Configuration reload will only affect new or resumed files
 
-If a log file has not been modified in this time period, it will be closed and
-Log Courier will simply watch it for modifications. If the file is modified it
-will be reopened.
+If a log file has not been successfuly read from this time period, it will be
+closed and Log Courier will simply watch it for modifications. If the file is
+modified it will be reopened.
 
-If a log file that is being harvested is deleted, it will remain on disk until
-Log Courier closes it. Therefore it is important to keep this value sensible to
-ensure old log files are not kept open preventing deletion.
+### `hold_time`
+
+Duration. Optional. Default: "96h"
+Configuration reload will only affect new or resumed files
+
+If a log file is deleted, and this amount of time has passed and Log Courier still
+has the file open, the file will be closed regardless of whether data will be lost.
+
+This is a failsafe to ensure that a blocked pipeline does not cause deleted files
+to be held open indefinitely, eventually causing the disk space to fill. This will
+mean that disk usage cannot be used to detect issues sending logs and so additional
+monitoring may be needed to detect this.
+
+Set to 0 to disable and keep files open indefinitely until all data inside them is
+sent and the dead_time passes.
 
 ### `fields`
 

--- a/lc-lib/harvester/config.go
+++ b/lc-lib/harvester/config.go
@@ -30,6 +30,7 @@ import (
 const (
 	defaultStreamAddPathField bool          = true
 	defaultStreamDeadTime     time.Duration = 1 * time.Hour
+	defaultStreamHoldTime     time.Duration = 96 * time.Hour
 
 	defaultGeneralLineBufferBytes int64 = 16384
 	defaultGeneralMaxLineBytes    int64 = 1048576
@@ -42,6 +43,7 @@ type StreamConfig struct {
 
 	AddPathField bool          `config:"add path field"`
 	DeadTime     time.Duration `config:"dead time"`
+	HoldTime     time.Duration `config:"hold time"`
 }
 
 // Defaults sets the default harvester stream configuration
@@ -49,6 +51,7 @@ type StreamConfig struct {
 func (sc *StreamConfig) Defaults() {
 	sc.AddPathField = defaultStreamAddPathField
 	sc.DeadTime = defaultStreamDeadTime
+	sc.HoldTime = defaultStreamHoldTime
 }
 
 // Init initialises the configuration
@@ -78,8 +81,7 @@ func (sc *StreamConfig) NewHarvester(ctx context.Context, path string, fileinfo 
 		offset:       offset,
 		lastEOF:      nil,
 		backOffTimer: time.NewTimer(0),
-		// TODO: Configurable meter timer? Use same as statCheck timer
-		meterTimer: time.NewTimer(10 * time.Second),
+		blockedTimer: time.NewTimer(1 * time.Second),
 	}
 
 	<-ret.backOffTimer.C

--- a/lc-lib/prospector/info.go
+++ b/lc-lib/prospector/info.go
@@ -137,3 +137,12 @@ func (pi *prospectorInfo) update(fileinfo os.FileInfo, iteration uint32) {
 
 	pi.lastSeen = iteration
 }
+
+func (pi *prospectorInfo) maybeOrphaned() {
+	pi.orphaned = orphanedMaybe
+}
+
+func (pi *prospectorInfo) setOrphaned() {
+	pi.orphaned = orphanedYes
+	pi.harvester.SetOrphaned()
+}

--- a/lc-lib/prospector/prospector.go
+++ b/lc-lib/prospector/prospector.go
@@ -171,10 +171,10 @@ func (p *Prospector) runOnce() bool {
 				continue
 			}
 			delete(p.prospectorindex, info.file)
-			info.orphaned = orphanedMaybe
+			info.maybeOrphaned()
 		}
 		if info.orphaned == orphanedMaybe {
-			info.orphaned = orphanedYes
+			info.setOrphaned()
 			p.registrarSpool.Add(registrar.NewDeletedEvent(info.ctx))
 		}
 	}
@@ -252,7 +252,7 @@ func (p *Prospector) processFile(file string, cfg *FileConfig) {
 		if isKnown {
 			if info.status != statusInvalid {
 				// The current entry is not an error, orphan it so we can log one
-				info.orphaned = orphanedMaybe
+				info.maybeOrphaned()
 			} else if info.err.Error() == err.Error() {
 				// The same error occurred - don't log it again
 				info.update(nil, p.iteration)
@@ -323,7 +323,7 @@ func (p *Prospector) processFile(file string, cfg *FileConfig) {
 	} else {
 		if !info.identity.SameAs(fileinfo) {
 			// Keep the old file in case we find it again shortly
-			info.orphaned = orphanedMaybe
+			info.maybeOrphaned()
 
 			if previous, previousinfo := p.lookupFileIds(file, fileinfo); previous != "" {
 				// Symlinks could mean we see the same file twice - skip if we have


### PR DESCRIPTION
Implement orphan flag in harvester and hold time configuration to allow deliberate data loss in failure scenarios where pipeline is blocked or too slow

Repair dead time processing that had some unintended actions and that hold time now replaces
Fixes #355
Fixes #261