### PR TITLE
Fix syslog progname (prefix) being full path (os.Args[0]) because pre…

### DIFF
--- a/fact-courier/fact-courier.go
+++ b/fact-courier/fact-courier.go
@@ -37,7 +37,7 @@ var (
 )
 
 func main() {
-	app = core.NewApp("Fact Courier", "fact-courier", core.LogCourierVersion)
+	app = core.NewApp("Fact Courier", core.LogCourierVersion)
 	app.StartUp()
 
 	if app.Config().Section("admin").(*admin.Config).Enabled {

--- a/lc-lib/core/app.go
+++ b/lc-lib/core/app.go
@@ -33,7 +33,6 @@ import (
 // App represents a courier application
 type App struct {
 	name       string
-	binName    string
 	version    string
 	configFile string
 	pipeline   *Pipeline
@@ -43,7 +42,7 @@ type App struct {
 }
 
 // NewApp creates a new courier application
-func NewApp(name, binName, version string) *App {
+func NewApp(name, version string) *App {
 	return &App{
 		name:       name,
 		version:    version,

--- a/lc-lib/core/app_nonwindows.go
+++ b/lc-lib/core/app_nonwindows.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path"
 	"syscall"
 	"unsafe"
 
@@ -57,7 +58,7 @@ func (a *App) configureLoggingPlatform(backends *[]logging.Backend) error {
 	}
 
 	if a.config.General().LogSyslog {
-		syslogBackend, err := logging.NewSyslogBackend(a.binName)
+		syslogBackend, err := logging.NewSyslogBackend(path.Base(os.Args[0]))
 		if err != nil {
 			return fmt.Errorf("Failed to open syslog: %s", err)
 		}

--- a/log-carver/log-carver.go
+++ b/log-carver/log-carver.go
@@ -43,7 +43,7 @@ var (
 )
 
 func main() {
-	app = core.NewApp("Log Carver", "log-carver", core.LogCourierVersion)
+	app = core.NewApp("Log Carver", core.LogCourierVersion)
 	app.StartUp()
 
 	if app.Config().Section("admin").(*admin.Config).Enabled {

--- a/log-courier.go
+++ b/log-courier.go
@@ -44,7 +44,7 @@ var (
 )
 
 func main() {
-	app = core.NewApp("Log Courier", "log-courier", core.LogCourierVersion)
+	app = core.NewApp("Log Courier", core.LogCourierVersion)
 	flag.BoolVar(&stdin, "stdin", false, "Read from stdin instead of files listed in the config file")
 	flag.BoolVar(&fromBeginning, "from-beginning", false, "On first run, read new files from the beginning instead of the end")
 	app.StartUp()


### PR DESCRIPTION
…fix was static and not being passed as prefix so it was empty

Fixes #384